### PR TITLE
Change in test_build.yaml

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -61,11 +61,11 @@ jobs:
         
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: cmake --build . --config $BUILD_TYPE
+        run: cmake --build .
         
       - name: Compile and install
         working-directory: ${{github.workspace}}/build
-        run: cmake --install . --config $BUILD_TYPE
+        run: cmake --install .
     
       - name: Check test file compilation against static libs
         working-directory: ${{github.workspace}}/user_test


### PR DESCRIPTION
Removed the config option when building and installing on Windows, as NMake is a single config generator